### PR TITLE
refactor: 优化前端依赖和产物体积

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "code-assist",
   "displayName": "Gauss Code Assist",
   "description": "",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "engines": {
     "vscode": "^1.98.0"
   },

--- a/src-web/package.json
+++ b/src-web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "webview",
+  "name": "vscode-ext-code-assist-webview",
   "private": true,
   "version": "0.1.0",
   "type": "module",
@@ -12,7 +12,6 @@
     "core-js": "^3.8.3",
     "element-plus": "^2.9.9",
     "highlight.js": "^11.11.1",
-    "js-tiktoken": "^1.0.20",
     "localforage": "^1.10.0",
     "marked": "^15.0.11",
     "marked-highlight": "^2.2.1",

--- a/src-web/src/components/AppFooter.vue
+++ b/src-web/src/components/AppFooter.vue
@@ -58,6 +58,7 @@ import { ChatModel, type IModel } from "@/setting";
 import { ref, watch } from "vue";
 import SettingDialog from "./AppSettingDialog.vue";
 import { marked } from "@/utils/marked";
+import { VideoPause, Promotion } from '@element-plus/icons-vue';
 
 const modelValue = defineModel<string>({ required: true });
 

--- a/src-web/src/main.ts
+++ b/src-web/src/main.ts
@@ -9,9 +9,5 @@ import 'element-plus/theme-chalk/dark/css-vars.css';
 import "element-plus/dist/index.css";
 import "./styles/index.css";
 
-import * as ElementPlusIconsVue from '@element-plus/icons-vue';
 const app = createApp(App);
-for (const [key, component] of Object.entries(ElementPlusIconsVue)) {
-   app.component(key, component);
-}
 app.mount("#app");

--- a/src-web/src/utils/hljs.ts
+++ b/src-web/src/utils/hljs.ts
@@ -1,0 +1,31 @@
+import hljs from 'highlight.js/lib/core';
+import javascript from 'highlight.js/lib/languages/javascript'
+import java from 'highlight.js/lib/languages/java';
+import css from 'highlight.js/lib/languages/css';
+import less from 'highlight.js/lib/languages/less';
+import go from 'highlight.js/lib/languages/go';
+import php from 'highlight.js/lib/languages/php';
+import python from 'highlight.js/lib/languages/python';
+import ruby from 'highlight.js/lib/languages/ruby';
+import stylus from 'highlight.js/lib/languages/stylus';
+import typescript from 'highlight.js/lib/languages/typescript';
+import xml from 'highlight.js/lib/languages/xml';
+
+const languages = {
+    javascript,
+    java,
+    css,
+    less,
+    go,
+    php,
+    python,
+    ruby,
+    stylus,
+    typescript,
+    xml
+}
+Object.keys(languages).forEach(key => {
+    hljs.registerLanguage(key, languages[key])
+})
+
+export default hljs;

--- a/src-web/src/utils/marked.ts
+++ b/src-web/src/utils/marked.ts
@@ -1,4 +1,4 @@
-import hljs from 'highlight.js';
+import hljs from './hljs';
 import { Marked } from "marked";
 import { markedHighlight } from "marked-highlight";
 


### PR DESCRIPTION
- 更新主项目和webview项目的版本号和名称
- 移除未使用的js-tiktoken依赖
- 重构highlight.js导入方式，改为按需加载语言
- 移除全局注册的ElementPlus图标组件，改为按需导入
- 添加自定义hljs工具文件支持特定语言高亮